### PR TITLE
Added error catch before parsing JSON

### DIFF
--- a/lib/qsys-core.js
+++ b/lib/qsys-core.js
@@ -95,32 +95,36 @@ module.exports = function (RED) {
 
             for (let i = 0; i < data.length; i++) {
                 if (data[i] == 0x0 && data.length != 0) {
-                    let obj = JSON.parse((Buffer.from(rx)).toString());
-                    if ('method' in obj) {
-                        switch (obj.method) {
-                            case 'EngineStatus':
-                                if (obj.params.State === 'Active') {
-                                    this.emit('ready');
-                                }
-                                else if (isRedundant && obj.params.State === 'Standby') {
-                                    this.socket.destroy()
-                                    this.socket = net.connect(port, host);
-                                }
-                                
-                                break;
-                            case 'ChangeGroup.Poll':
-                                let changes = obj.params.Changes;
-                                if (changes.length !== 0) {
-                                    for (let i = 0; i < changes.length; i++) {
-                                        this.emit('rx', changes[i]);
+                    try {
+                        let obj = JSON.parse((Buffer.from(rx)).toString());
+                        if ('method' in obj) {
+                            switch (obj.method) {
+                                case 'EngineStatus':
+                                    if (obj.params.State === 'Active') {
+                                        this.emit('ready');
                                     }
-                                }
-                                break;
-                            default:
-                                break;
+                                    else if (isRedundant && obj.params.State === 'Standby') {
+                                        this.socket.destroy()
+                                        this.socket = net.connect(port, host);
+                                    }
+                                    
+                                    break;
+                                case 'ChangeGroup.Poll':
+                                    let changes = obj.params.Changes;
+                                    if (changes.length !== 0) {
+                                        for (let i = 0; i < changes.length; i++) {
+                                            this.emit('rx', changes[i]);
+                                        }
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
                         }
-                    }
                     rx = [];
+                    } catch (err) {
+                        this.error(err.toString());
+                    }
                 }
                 else {
                     rx.push(data[i]);


### PR DESCRIPTION
After reporting the issue which I assumed was Q-SYS 9.10.1, I experienced the same issues on 9.9.0 so ended up doing a packet capture and found malformed JSON being sent.

I've added the `try` to catch any errors with malformed JSON.